### PR TITLE
Remove dependency on mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,4 @@ include-package-data = true
 [dependency-groups]
 test = [
     "pytest",
-    "mock",
 ]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import laboratory
 from laboratory import Experiment

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 import laboratory


### PR DESCRIPTION
`mock` is imported from the standard library and removed as a dependency.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212331409472604